### PR TITLE
Bug Reort build fails due to duplicate ndkVersion  

### DIFF
--- a/optifit app/android/app/build.gradle.kts
+++ b/optifit app/android/app/build.gradle.kts
@@ -9,7 +9,6 @@ android {
     ndkVersion = "27.0.12077973"
     namespace = "com.example.gymbuddy"
     compileSdk = flutter.compileSdkVersion
-    ndkVersion = flutter.ndkVersion
 
     compileOptions {
         sourceCompatibility = JavaVersion.VERSION_11


### PR DESCRIPTION
### PR Description:

**Problem:**  
The `ndkVersion` is defined twice in `android/app/build.gradle.kts`.  
One is correct (`"27.0.12077973"`) and the other is an old fallback (`flutter.ndkVersion`), causing a conflict.

**Solution:**  
- Removed the duplicate/fallback `ndkVersion` entry.  

**Related Issue:**  
Closes #34
