### PR TITLE
Update CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -142,4 +142,14 @@ git push origin issue-42-fix-login-validation
 - **Issues:** Ask questions in the issue comments.
 - **Discussions:** Use GitHub Discussions for general queries.
 
+### 8. Contributors
+
+[![Contributors](https://contrib.rocks/image?repo=Aditya-dev2005/OptiFit)](https://github.com/Aditya-dev2005/OptiFit/graphs/contributors)
+
+### Contributors not shown above:
+- [Aditya-dev2005](https://github.com/Aditya-dev2005)
+- [MasterAffan](https://github.com/MasterAffan)
+- [poojasheoran12](https://github.com/poojasheoran12)
+
+Replace your-username with the actual repo owner.
 Thank you for contributing to OptiFit! Together, we can make fitness more accessible and effective for everyone.


### PR DESCRIPTION
## Description
This PR updates the contributors section in the README to use the contrib.rocks badge for automatic contributor display, and adds a manual list of contributors missing from the badge as clickable links. This ensures stable and consistent visibility of all contributors both on GitHub web and mobile views.

## Related Issue
Closes #38

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Enhancement
- [x] Documentation
- [ ] Other (please specify)

## How Has This Been Tested?
Tested by previewing the README on GitHub’s web and mobile views. Verified that the contributors badge loads and displays contributors properly, and the manual list of missing contributors is visible with functional links. The layout remains clean and responsive.

## Screenshots (if applicable)
<!-- Add screenshots if helpful -->

## Checklist
- [x] My code follows the project’s style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code where necessary
- [ ] I have added/updated tests (if applicable)
- [x] Documentation has been updated (if needed)
