### PR TITLE
Add Unit Tests for Backend 

### DIFF
--- a/optifit_backend/requirements.txt
+++ b/optifit_backend/requirements.txt
@@ -1,0 +1,10 @@
+Flask==2.3.2
+opencv-python-headless==4.9.0.80
+mediapipe==0.10.21
+numpy==1.26.4
+pyngrok==7.3.0
+
+#Testing dependencies 
+pytest==8.3.2
+pytest-flask==1.3.0
+pytest-cov==5.0.0

--- a/optifit_backend/tests/conftest.py
+++ b/optifit_backend/tests/conftest.py
@@ -1,0 +1,8 @@
+import pytest
+from optifit_backend.app import app
+
+@pytest.fixture
+def client():
+    app.config["TESTING"] = True
+    with app.test_client() as client:
+        yield client

--- a/optifit_backend/tests/test_ping.py
+++ b/optifit_backend/tests/test_ping.py
@@ -1,0 +1,5 @@
+
+def test_ping(client):
+    response = client.get('/ping')
+    assert response.status_code == 200
+    assert response.get_json() == {"message": "Server is live!"}

--- a/optifit_backend/tests/test_processed.py
+++ b/optifit_backend/tests/test_processed.py
@@ -1,0 +1,4 @@
+
+def test_processed(client):
+    response = client.get("/processed/nonexistent.mp4")
+    assert response.status_code == 404

--- a/optifit_backend/tests/test_result.py
+++ b/optifit_backend/tests/test_result.py
@@ -1,0 +1,5 @@
+
+def test_result(client):
+    response = client.get("/result/invalid_id")
+    assert response.status_code == 404
+    assert response.get_json()["status"] == "not_found"

--- a/optifit_backend/tests/test_upload.py
+++ b/optifit_backend/tests/test_upload.py
@@ -1,0 +1,26 @@
+import io
+
+def test_uploading_video(client, tmp_path, monkeypatch):
+    def fake_process_squat_video(input_path, output_path):
+        with open(input_path, "wb") as f:
+            f.write(b"Fake video data")
+        with open(output_path, "wb") as f:
+            f.write(b"Fake processed video data")
+
+    monkeypatch.setattr("app.process_squat_video", fake_process_squat_video)
+
+    video_file = tmp_path / "test_video.mp4"
+    with open(video_file, "wb") as f:
+        f.write(b"Test video data")
+
+    with open(video_file, "rb") as f:
+        response = client.post(
+            "/upload",
+            data={"video": (io.BytesIO(f.read()), "test_video.mp4")}
+        )
+
+    assert response.status_code == 200
+    json_data = response.get_json()
+    assert json_data["status"] == "processing"
+    assert "job_id" in json_data
+    assert "video_url" in json_data


### PR DESCRIPTION
## What is this pr introduce ?

This PR adds `pytest-based` unit tests for the backend API, covering /ping, /upload, /result/<job_id>, and /processed/<filename> endpoints.
 File uploads and video processing are mocked for fast and reliable testing.

## Closes #13
